### PR TITLE
Solving: ImportError: No module named 'gsem'

### DIFF
--- a/bin/gsem
+++ b/bin/gsem
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    libdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    libdir = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
     if os.path.exists(os.path.join(libdir, "gsem")):
         sys.path.insert(0, libdir)
     from gsem.cli import main


### PR DESCRIPTION
Python could not find the gsem package, especially not if I called the bin/gsem program through a symlink. But as I saw there was an additional error by not getting the parent directory of the gsem executable.
The change works for me no matter from where I call the program.